### PR TITLE
make compatible with flutter web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.3]
+
+- fix: Web compatibility
+
 ## [0.0.2]
 
 - chore: replace `Map` with `Map<String, dyanmic>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 ## [0.0.3]
 
 - fix: binding filter bug on realtimeSubscription trigger method
->>>>>>> origin/main
 
 ## [0.0.2]
 

--- a/lib/src/websocket_io.dart
+++ b/lib/src/websocket_io.dart
@@ -1,0 +1,7 @@
+import 'package:web_socket_channel/io.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+WebSocketChannel createWebSocketClient(
+    String url, Map<String, String> headers) {
+  return IOWebSocketChannel.connect(url, headers: headers);
+}

--- a/lib/src/websocket_stub.dart
+++ b/lib/src/websocket_stub.dart
@@ -1,0 +1,7 @@
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+WebSocketChannel createWebSocketClient(
+    String url, Map<String, String> headers) {
+  throw UnimplementedError(
+      'Websocket Client not implemented for this platform');
+}

--- a/lib/src/websocket_web.dart
+++ b/lib/src/websocket_web.dart
@@ -1,0 +1,7 @@
+import 'package:web_socket_channel/html.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+WebSocketChannel createWebSocketClient(
+    String url, Map<String, String> headers) {
+  return HtmlWebSocketChannel.connect(url);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: realtime_client
 description: Listens to changes in a PostgreSQL Database and via websockets. This is for usage with Supabase Realtime server.
-version: 0.0.2
+version: 0.0.3
 homepage: "https://supabase.io"
 repository: "https://github.com/supabase/realtime-dart"
 

--- a/test/socket_test.dart
+++ b/test/socket_test.dart
@@ -11,7 +11,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'socket_test_stubs.dart';
 
-typedef IOWebSocketChannelClosure = IOWebSocketChannel Function(
+typedef WebSocketChannelClosure = WebSocketChannel Function(
     String url, Map<String, String> headers);
 
 void main() {
@@ -53,7 +53,7 @@ void main() {
         'error': [],
         'message': [],
       });
-      expect(socket.transport is IOWebSocketChannelClosure, true);
+      expect(socket.transport is WebSocketChannelClosure, true);
       expect(socket.timeout, const Duration(milliseconds: 10000));
       expect(socket.longpollerTimeout, 20000);
       expect(socket.heartbeatIntervalMs, 30000);
@@ -78,7 +78,7 @@ void main() {
         'error': [],
         'message': [],
       });
-      expect(socket.transport is IOWebSocketChannelClosure, true);
+      expect(socket.transport is WebSocketChannelClosure, true);
       expect(socket.timeout, const Duration(milliseconds: 40000));
       expect(socket.longpollerTimeout, 50000);
       expect(socket.heartbeatIntervalMs, 60000);
@@ -97,14 +97,15 @@ void main() {
     });
 
     test('returns endpoint with parameters', () {
-      final socket = RealtimeClient('ws://example.org/chat', params: {'foo': 'bar'});
+      final socket =
+          RealtimeClient('ws://example.org/chat', params: {'foo': 'bar'});
       expect(socket.endPointURL(),
           'ws://example.org/chat/websocket?foo=bar&vsn=1.0.0');
     });
 
     test('returns endpoint with apikey', () {
-      final socket =
-          RealtimeClient('ws://example.org/chat', params: {'apikey': '123456789'});
+      final socket = RealtimeClient('ws://example.org/chat',
+          params: {'apikey': '123456789'});
       expect(socket.endPointURL(),
           'ws://example.org/chat/websocket?apikey=123456789&vsn=1.0.0');
     });
@@ -318,7 +319,8 @@ void main() {
       mockedSocket.connect();
       mockedSocket.connState = SocketStates.open;
 
-      final message = Message(topic: topic, payload: payload, event: event, ref: ref);
+      final message =
+          Message(topic: topic, payload: payload, event: event, ref: ref);
       mockedSocket.push(message);
 
       verify(mockedSink.add(jsonData));
@@ -330,7 +332,8 @@ void main() {
 
       expect(mockedSocket.sendBuffer.length, 0);
 
-      final message = Message(topic: topic, payload: payload, event: event, ref: ref);
+      final message =
+          Message(topic: topic, payload: payload, event: event, ref: ref);
       mockedSocket.push(message);
 
       verifyNever(mockedSink.add(jsonData));


### PR DESCRIPTION
## What kind of change does this PR introduce?

This change introduces an indirection in creating the default websocket to allow for web compatibility

## What is the current behavior?

Web doesn't work unless you create a realtime client directly with the HtmlWebSocketChannel. Web support is missing on pub.dev in both `supabase` and `realtime_client`
Example error:
`Socket error: Unsupported operation: Platform._version`

## What is the new behavior?

No new behavior except for the web

## Additional context

- Dart has conditional imports to separate implementations of web / non-web behavior
https://dart.dev/guides/libraries/create-library-packages#conditionally-importing-and-exporting-library-files