### PR TITLE
fix: default reconnectAfterMs function throws RangeError

### DIFF
--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -36,7 +36,7 @@ class RealtimeClient {
   Logger? logger;
   late Encoder encode;
   late Decoder decode;
-  late int Function(int) reconnectAfterMs;
+  late TimerCalculation reconnectAfterMs;
   WebSocketChannel? conn;
   List sendBuffer = [];
   Map<String, List<Function>> stateChangeCallbacks = {
@@ -68,16 +68,14 @@ class RealtimeClient {
     this.timeout = Constants.defaultTimeout,
     this.heartbeatIntervalMs = 30000,
     this.longpollerTimeout = 20000,
-    int Function(int)? reconnectAfterMs,
+    TimerCalculation? reconnectAfterMs,
     this.logger,
     this.params = const {},
     this.headers = const {},
   })  : endPoint = '$endPoint/${Transports.websocket}',
         transport = transport ?? createWebSocketClient {
-    this.reconnectAfterMs = reconnectAfterMs ??
-        (int tries) {
-          return [1000, 2000, 5000, 10000][tries - 1];
-        };
+    this.reconnectAfterMs =
+        reconnectAfterMs ?? RetryTimer.createRetryFunction();
     this.encode = encode ??
         (dynamic payload, Function(String result) callback) =>
             callback(json.encode(payload));

--- a/lib/src/retry_timer.dart
+++ b/lib/src/retry_timer.dart
@@ -3,6 +3,9 @@ import 'dart:async';
 typedef TimerCallback = void Function();
 typedef TimerCalculation = int Function(int tries);
 
+// Need to limit doubling to avoid overflow, this limit gives 1 million times the first delay
+const maxShift = 20;
+
 /// Creates a timer that accepts a `timerCalc` function to perform
 /// calculated timeout retries, such as exponential backoff.
 ///
@@ -17,6 +20,7 @@ typedef TimerCalculation = int Function(int tries);
 /// reconnectTimer.scheduleTimeout() // fires after 5000
 /// reconnectTimer.reset()
 /// reconnectTimer.scheduleTimeout() // fires after 1000
+///
 /// ```
 class RetryTimer {
   final TimerCallback callback;
@@ -41,5 +45,15 @@ class RetryTimer {
       _tries = _tries + 1;
       callback();
     });
+  }
+
+  // Generate an exponential backoff function with first and max delays
+  static TimerCalculation createRetryFunction(
+      {int firstDelay = 1000, int maxDelay = 10000}) {
+    return (int tries) {
+      final shiftAmount = (tries - 1) > maxShift ? maxShift : tries - 1;
+      final delay = firstDelay << shiftAmount;
+      return delay > maxDelay ? maxDelay : delay;
+    };
   }
 }

--- a/test/retry_timer_test.dart
+++ b/test/retry_timer_test.dart
@@ -1,0 +1,19 @@
+import 'package:realtime_client/src/retry_timer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('retry function should stop at maxDelay', () {
+    final backoff = RetryTimer.createRetryFunction(maxDelay: 5000);
+    expect(backoff(100), 5000);
+  });
+
+  test('retry function should return first delay on tries == 1', () {
+    final backoff = RetryTimer.createRetryFunction(firstDelay: 1000);
+    expect(backoff(1), 1000);
+  });
+
+  test('retry function should return firstDelay * 4 for tries 3', () {
+    final backoff = RetryTimer.createRetryFunction(firstDelay: 1000);
+    expect(backoff(3), 1000 * 4);
+  });
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and code refactor 

## What is the current behavior?

When a subscription tries more than 4 times, there is a `RangeError` thrown.

Example from a Flutter Web stacktrace - 

```
Error: RangeError (index): Index out of range: index should be less than 4: 4
    at Object.throw_ [as throw] (http://localhost:44541/dart_sdk.js:5334:11)
    at Array.[dartx._get] (http://localhost:44541/dart_sdk.js:16031:21)
    at retry_timer.RetryTimer.new.<anonymous> (http://localhost:44541/packages/realtime_client/src/realtime_client.dart.lib.js:606:67)
    at retry_timer.RetryTimer.new.scheduleTimeout (http://localhost:44541/packages/realtime_client/src/retry_timer.dart.lib.js:53:118)
    at http://localhost:44541/packages/realtime_client/src/realtime_client.dart.lib.js:1146:26
    at realtime_subscription.Binding.new.<anonymous> (http://localhost:44541/packages/realtime_client/src/realtime_client.dart.lib.js:986:16)
    at realtime_subscription.RealtimeSubscription.new.trigger (http://localhost:44541/packages/realtime_client/src/realtime_client.dart.lib.js:1085:12)
    at realtime_client.RealtimeClient.new.[_triggerChanError] (http://localhost:44541/packages/realtime_client/src/realtime_client.dart.lib.js:531:17)
    at realtime_client.RealtimeClient.new.[_onConnClose] (http://localhost:44541/packages/realtime_client/src/realtime_client.dart.lib.js:514:32)
    at http://localhost:44541/packages/realtime_client/src/realtime_client.dart.lib.js:328:31
    at _RootZone.runGuarded (http://localhost:44541/dart_sdk.js:38798:11)
    at sendDone (http://localhost:44541/dart_sdk.js:32476:24)
    at _ControllerSubscription.new.[_sendDone] (http://localhost:44541/dart_sdk.js:32486:11)
    at _ControllerSubscription.new.[_close] (http://localhost:44541/dart_sdk.js:32398:26)
    at _SyncStreamController.new.[_sendDone] (http://localhost:44541/dart_sdk.js:35348:36)
    at _SyncStreamController.new.[_sendDone] (http://localhost:44541/dart_sdk.js:35458:32)
    at _SyncStreamController.new.[_closeUnchecked] (http://localhost:44541/dart_sdk.js:35140:26)
    at _SyncStreamController.new.close (http://localhost:44541/dart_sdk.js:35134:30)
    at http://localhost:44541/packages/stream_channel/src/stream_channel_controller.dart.lib.js:1157:39
    at _RootZone.runGuarded (http://localhost:44541/dart_sdk.js:38798:11)
    at sendDone (http://localhost:44541/dart_sdk.js:32476:24)
    at _ControllerSubscription.new.[_sendDone] (http://localhost:44541/dart_sdk.js:32486:11)
    at _ControllerSubscription.new.[_close] (http://localhost:44541/dart_sdk.js:32398:26)
    at _SyncStreamController.new.[_sendDone] (http://localhost:44541/dart_sdk.js:35348:36)
    at _SyncStreamController.new.[_sendDone] (http://localhost:44541/dart_sdk.js:35458:32)
    at _SyncStreamController.new.[_closeUnchecked] (http://localhost:44541/dart_sdk.js:35140:26)
    at _SyncStreamController.new.close (http://localhost:44541/dart_sdk.js:35134:30)
    at _StreamSinkWrapper.new.close (http://localhost:44541/dart_sdk.js:35493:31)
    at _GuaranteeSink.new.close (http://localhost:44541/packages/stream_channel/src/stream_channel_controller.dart.lib.js:1266:56)
    at http://localhost:44541/packages/web_socket_channel/src/copy/web_socket_impl.dart.lib.js:1403:37
    at _RootZone.runUnary (http://localhost:44541/dart_sdk.js:38889:58)
    at _FutureListener.then.handleValue (http://localhost:44541/dart_sdk.js:33875:29)
    at handleValueCallback (http://localhost:44541/dart_sdk.js:34435:49)
    at Function._propagateToListeners (http://localhost:44541/dart_sdk.js:34473:17)
    at _Future.new.[_complete] (http://localhost:44541/dart_sdk.js:34307:25)
    at Object._cancelAndValue (http://localhost:44541/dart_sdk.js:39325:24)
    at http://localhost:44541/dart_sdk.js:19695:17
    at Object._checkAndCall (http://localhost:44541/dart_sdk.js:5544:16)
    at Object.dcall (http://localhost:44541/dart_sdk.js:5549:17)
    at WebSocket.<anonymous> (http://localhost:44541/dart_sdk.js:105368:23)
Error: RangeError (index): Index out of range: index should be less than 4: 4
    at Object.throw_ [as throw] (http://localhost:44541/dart_sdk.js:5334:11)
    at Array.[dartx._get] (http://localhost:44541/dart_sdk.js:16031:21)
    at retry_timer.RetryTimer.new.<anonymous> (http://localhost:44541/packages/realtime_client/src/realtime_client.dart.lib.js:606:67)
    at retry_timer.RetryTimer.new.scheduleTimeout (http://localhost:44541/packages/realtime_client/src/retry_timer.dart.lib.js:53:118)
    at realtime_subscription.RealtimeSubscription.new.rejoinUntilConnected (http://localhost:44541/packages/realtime_client/src/realtime_client.dart.lib.js:959:26)
    at retry_timer.RetryTimer.new.<anonymous> (http://localhost:44541/packages/realtime_client/src/realtime_client.dart.lib.js:1125:76)
    at http://localhost:44541/packages/realtime_client/src/retry_timer.dart.lib.js:55:14
    at internalCallback (http://localhost:44541/dart_sdk.js:25104:11)
```

## What is the new behavior?

- Retries above the number of expected retries returns the maximum delay
- Refactor default retry function to be parameterized and in `RetryTimer` class instead of `RealtimeClient`

## Additional context


