### PR TITLE
Convert typedefs in realtime_client.dart to function types

### DIFF
--- a/test/socket_test.dart
+++ b/test/socket_test.dart
@@ -52,7 +52,10 @@ void main() {
       expect(socket.timeout, const Duration(milliseconds: 10000));
       expect(socket.longpollerTimeout, 20000);
       expect(socket.heartbeatIntervalMs, 30000);
-      expect(socket.logger is Logger, false);
+      expect(
+          socket.logger is void Function(
+              String? kind, String? msg, dynamic data),
+          false);
       expect(socket.reconnectAfterMs is Function, true);
     });
 
@@ -77,7 +80,10 @@ void main() {
       expect(socket.timeout, const Duration(milliseconds: 40000));
       expect(socket.longpollerTimeout, 50000);
       expect(socket.heartbeatIntervalMs, 60000);
-      expect(socket.logger is Logger, true);
+      expect(
+          socket.logger is void Function(
+              String? kind, String? msg, dynamic data),
+          true);
       expect(socket.reconnectAfterMs is Function, true);
     });
   });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Converts all typedefs in realtime_client.dart to plain function types. 

Closes #12 

## What is the current behavior?

`Logger`, `Encoder`, `Decoder `, `WebSocketChannelProvider` are declared as typedefs. 

## What is the new behavior?

`Logger`, `Encoder`, `Decoder `, `WebSocketChannelProvider` are deleted and function types are used. 

## Additional context

This PR is a very debatable update, but I just wanted to explore possible implementation. 

Effective Dart has [PREFER inline function types over typedefs](https://dart.dev/guides/language/effective-dart/design#prefer-inline-function-types-over-typedefs) rule. It is worth stating that 
>It may still be worth defining a typedef if the function type is particularly long or frequently used. But in most cases, users want to see what the function type actually is right where it’s used, and the function type syntax gives them that clarity.

Since the `Logger`, `Encoder`, `Decoder `, `WebSocketChannelProvider` was not being frequently used, I thought it might be feasible to get rid of typedefs. 

One thing to note is that this update will be a breaking change for anyone using `Logger`, `Encoder`, `Decoder `, `WebSocketChannelProvider` in their code base. 

Open to feedback and discussions!