### PR TITLE
Fixed a bug where listening to all event types does not work

### DIFF
--- a/lib/src/realtime_subscription.dart
+++ b/lib/src/realtime_subscription.dart
@@ -195,7 +195,14 @@ class RealtimeSubscription {
       throw 'channel onMessage callbacks must return the payload, modified or unmodified';
     }
 
-    final filtered = _bindings.where((bind) => bind.event == event);
+    final filtered = _bindings.where((bind) {
+      /// bind all realtime events
+      if (bind.event == '*') {
+        return event == payload['type'];
+      } else {
+        return bind.event == event;
+      }
+    });
     for (final bind in filtered) {
       bind.callback(handledPayload, ref: ref);
     }

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -8,4 +8,49 @@ void main() {
     channel.sendJoin(const Duration(seconds: 5));
     expect(channel.isJoining(), isTrue);
   });
+
+  group('on', () {
+    late RealtimeSubscription channel;
+
+    setUp(() {
+      channel = RealtimeSubscription('topic', RealtimeClient('endpoint'));
+    });
+
+    test('sets up callback for event', () {
+      var callbackCalled = 0;
+      channel.on('event', (dynamic payload, {String? ref}) => callbackCalled++);
+
+      channel.trigger('event', payload: {});
+      expect(callbackCalled, 1);
+    });
+
+    test('other event callbacks are ignored', () {
+      var eventCallbackCalled = 0;
+      var otherEventCallbackCalled = 0;
+      channel.on(
+          'event', (dynamic payload, {String? ref}) => eventCallbackCalled++);
+      channel.on('otherEvent',
+          (dynamic payload, {String? ref}) => otherEventCallbackCalled++);
+
+      channel.trigger('event', payload: {});
+      expect(eventCallbackCalled, 1);
+      expect(otherEventCallbackCalled, 0);
+    });
+
+    test('"*" bind all events', () {
+      var callbackCalled = 0;
+      channel.on('*', (dynamic payload, {String? ref}) => callbackCalled++);
+
+      channel.trigger('INSERT', payload: {});
+      expect(callbackCalled, 0);
+
+      channel.trigger('*', payload: {'type': 'INSERT'});
+      expect(callbackCalled, 0);
+
+      channel.trigger('INSERT', payload: {'type': 'INSERT'});
+      channel.trigger('UPDATE', payload: {'type': 'UPDATE'});
+      channel.trigger('DELETE', payload: {'type': 'DELETE'});
+      expect(callbackCalled, 3);
+    });
+  });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed a bug where subscribing on `*` does not fire callback. 

Closes https://github.com/supabase/supabase-dart/issues/32

## What is the current behavior?

Subscribing on `*` does not fire any of `INSERT`, `UPDATE`, or `DELETE` callbacks. 

## What is the new behavior?

Subscribing on `*` will fire all `INSERT`, `UPDATE`, and `DELETE` callbacks.