### PR TITLE
fix: Added channel tests and fixed a bug where _timeoutTimer never gets any values. 

### DIFF
--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -62,7 +62,7 @@ class Push {
   }
 
   void startTimeout() {
-    if (_timeoutTimer == null) return;
+    if (_timeoutTimer != null) return;
 
     _ref = _channel.socket.makeRef();
     final event = _channel.replyEventName(ref);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,6 @@ dependencies:
   web_socket_channel: ^2.0.0
 
 dev_dependencies:
-  clock: ^1.1.0
-  fake_async: ^1.2.0
   lint: ^1.5.1
   mocktail: ^0.1.0
   test: ^1.16.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
   web_socket_channel: ^2.0.0
 
 dev_dependencies:
+  clock: ^1.1.0
+  fake_async: ^1.2.0
   lint: ^1.5.1
   mocktail: ^0.1.0
   test: ^1.16.5

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -1,12 +1,127 @@
+import 'package:clock/clock.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:realtime_client/realtime_client.dart';
+import 'package:realtime_client/src/constants.dart';
 import 'package:test/test.dart';
 
 void main() {
+  late RealtimeClient socket;
+  late RealtimeSubscription channel;
+
+  const defaultRef = 1;
+
   test('channel should be initially closed', () {
     final channel = RealtimeSubscription('topic', RealtimeClient('endpoint'));
     expect(channel.isClosed(), isTrue);
     channel.sendJoin(const Duration(seconds: 5));
     expect(channel.isJoining(), isTrue);
+  });
+
+  group('constructor', () {
+    setUp(() {
+      socket = RealtimeClient('', timeout: const Duration(seconds: 1234));
+      channel = RealtimeSubscription('topic', socket, params: {'one': 'two'});
+    });
+
+    test('sets defaults', () {
+      expect(channel.isClosed(), true);
+      expect(channel.topic, 'topic');
+      expect(channel.params, {'one': 'two'});
+      expect(channel.socket, socket);
+    });
+
+    test('sets up joinPush object', () {
+      final joinPush = channel.subscribe();
+      // const joinPush = channel.joinPush;
+
+      // expect(joinPush.channel, matcher)
+      expect(joinPush.payload, {'one': 'two'});
+      // expect(joinPush.event, 'phx_join);
+      expect(joinPush.timeout, const Duration(seconds: 1234));
+
+      // assert.deepEqual(joinPush.channel, channel)
+      // assert.deepEqual(joinPush.payload, { one: 'two' })
+      // assert.equal(joinPush.event, 'phx_join')
+      // assert.equal(joinPush.timeout, 1234)
+    });
+  });
+
+  group('join', () {
+    setUp(() {
+      socket = RealtimeClient('wss://example.com/socket');
+      channel = socket.channel('topic', chanParams: {'one': 'two'});
+    });
+
+    test('sets state to joining', () {
+      channel.subscribe();
+
+      // expect(channel.state, 'joining');
+      // assert.equal(channel.state, 'joining')
+    });
+
+    test('sets joinedOnce to true', () {
+      // expect(channel.joinnedOnce, false);
+      // assert.ok(!channel.joinedOnce)
+
+      channel.subscribe();
+
+      // expect(channel.joinnedOnce, true);
+      // assert.ok(channel.joinedOnce)
+    });
+
+    test('throws if attempting to join multiple times', () {
+      channel.subscribe();
+
+      expect(() => channel.subscribe(), throwsA(const TypeMatcher<String>()));
+    });
+
+    test('triggers socket push with channel params', () {
+      // sinon.stub(socket, 'makeRef').callsFake(() => defaultRef)
+      // const spy = sinon.spy(socket, 'push')
+
+      channel.subscribe();
+
+      // assert.ok(spy.calledOnce)
+      // assert.ok(
+      //   spy.calledWith({
+      //     topic: 'topic',
+      //     event: 'phx_join',
+      //     payload: { one: 'two' },
+      //     ref: defaultRef,
+      //   })
+      // );
+    });
+
+    test('can set timeout on joinPush', () {
+      const newTimeout = Duration(seconds: 2000);
+      final joinPush = channel.subscribe(timeout: newTimeout);
+
+      expect(joinPush.timeout, const Duration(seconds: 2000));
+    });
+
+    group('timeout behavior', () {
+      T runWithTiming<T>(T Function() callback) {
+        return callback();
+      }
+
+      test('succeeds before timeout', () {
+        final timeout = socket.timeout;
+
+        FakeAsync().run((async) {
+          runWithTiming(() {
+            socket.connect();
+            async.elapse(timeout ~/ 2);
+            channel.trigger('ok');
+            // expect(channel.state, 'joined');
+            // assert.equal(channel.state, 'joined')
+            async.elapse(timeout);
+            // expect(push called, 1);
+            // assert.equal(spy.callCount, 1)
+          });
+        });
+      });
+    });
   });
 
   group('on', () {

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -1,15 +1,12 @@
-import 'package:mocktail/mocktail.dart';
 import 'package:realtime_client/realtime_client.dart';
 import 'package:realtime_client/src/push.dart';
 import 'package:test/test.dart';
-
-class MockRealtimeClient extends Mock implements RealtimeClient {}
 
 void main() {
   late RealtimeClient socket;
   late RealtimeSubscription channel;
 
-  final defaultRef = '1';
+  const defaultRef = '1';
 
   test('channel should be initially closed', () {
     final channel = RealtimeSubscription('topic', RealtimeClient('endpoint'));

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -14,7 +14,7 @@ void main() {
   test('channel should be initially closed', () {
     final channel = RealtimeSubscription('topic', RealtimeClient('endpoint'));
     expect(channel.isClosed(), isTrue);
-    channel.sendJoin(const Duration(milliseconds: 5));
+    channel.sendJoin(const Duration(seconds: 5));
     expect(channel.isJoining(), isTrue);
   });
 

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -1,5 +1,3 @@
-import 'package:clock/clock.dart';
-import 'package:fake_async/fake_async.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realtime_client/realtime_client.dart';
 import 'package:realtime_client/src/push.dart';
@@ -180,6 +178,34 @@ void main() {
       expect(callBackEventCalled1, 0);
       expect(callbackEventCalled2, 0);
       expect(callbackOtherCalled, 1);
+    });
+  });
+
+  group('unsubscribe', () {
+    setUp(() {
+      socket = RealtimeClient('/socket');
+
+      channel = socket.channel('topic', chanParams: {'one': 'two'});
+      channel.subscribe().trigger('ok', {});
+    });
+
+    test("closes channel on 'ok' from server", () {
+      final anotherChannel =
+          socket.channel('another', chanParams: {'three': 'four'});
+      expect(socket.channels.length, 2);
+
+      channel.unsubscribe().trigger('ok', {});
+
+      expect(socket.channels.length, 1);
+      expect(socket.channels[0], anotherChannel);
+    });
+
+    test("sets state to closed on 'ok' event", () {
+      expect(channel.isClosed(), false);
+
+      channel.unsubscribe().trigger('ok', {});
+
+      expect(channel.isClosed(), true);
     });
   });
 }

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -1,5 +1,4 @@
 import 'package:realtime_client/realtime_client.dart';
-import 'package:realtime_client/src/push.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -1,26 +1,23 @@
-import 'package:clock/clock.dart';
-import 'package:fake_async/fake_async.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realtime_client/realtime_client.dart';
-import 'package:realtime_client/src/constants.dart';
 import 'package:test/test.dart';
+
+class MockRealtimeClient extends Mock implements RealtimeClient {}
 
 void main() {
   late RealtimeClient socket;
   late RealtimeSubscription channel;
 
-  const defaultRef = 1;
-
   test('channel should be initially closed', () {
     final channel = RealtimeSubscription('topic', RealtimeClient('endpoint'));
     expect(channel.isClosed(), isTrue);
-    channel.sendJoin(const Duration(seconds: 5));
+    channel.sendJoin(const Duration(milliseconds: 5));
     expect(channel.isJoining(), isTrue);
   });
 
   group('constructor', () {
     setUp(() {
-      socket = RealtimeClient('', timeout: const Duration(seconds: 1234));
+      socket = RealtimeClient('', timeout: const Duration(milliseconds: 1234));
       channel = RealtimeSubscription('topic', socket, params: {'one': 'two'});
     });
 
@@ -29,21 +26,6 @@ void main() {
       expect(channel.topic, 'topic');
       expect(channel.params, {'one': 'two'});
       expect(channel.socket, socket);
-    });
-
-    test('sets up joinPush object', () {
-      final joinPush = channel.subscribe();
-      // const joinPush = channel.joinPush;
-
-      // expect(joinPush.channel, matcher)
-      expect(joinPush.payload, {'one': 'two'});
-      // expect(joinPush.event, 'phx_join);
-      expect(joinPush.timeout, const Duration(seconds: 1234));
-
-      // assert.deepEqual(joinPush.channel, channel)
-      // assert.deepEqual(joinPush.payload, { one: 'two' })
-      // assert.equal(joinPush.event, 'phx_join')
-      // assert.equal(joinPush.timeout, 1234)
     });
   });
 
@@ -56,18 +38,7 @@ void main() {
     test('sets state to joining', () {
       channel.subscribe();
 
-      // expect(channel.state, 'joining');
-      // assert.equal(channel.state, 'joining')
-    });
-
-    test('sets joinedOnce to true', () {
-      // expect(channel.joinnedOnce, false);
-      // assert.ok(!channel.joinedOnce)
-
-      channel.subscribe();
-
-      // expect(channel.joinnedOnce, true);
-      // assert.ok(channel.joinedOnce)
+      expect(channel.isJoining(), true);
     });
 
     test('throws if attempting to join multiple times', () {
@@ -76,51 +47,11 @@ void main() {
       expect(() => channel.subscribe(), throwsA(const TypeMatcher<String>()));
     });
 
-    test('triggers socket push with channel params', () {
-      // sinon.stub(socket, 'makeRef').callsFake(() => defaultRef)
-      // const spy = sinon.spy(socket, 'push')
-
-      channel.subscribe();
-
-      // assert.ok(spy.calledOnce)
-      // assert.ok(
-      //   spy.calledWith({
-      //     topic: 'topic',
-      //     event: 'phx_join',
-      //     payload: { one: 'two' },
-      //     ref: defaultRef,
-      //   })
-      // );
-    });
-
     test('can set timeout on joinPush', () {
-      const newTimeout = Duration(seconds: 2000);
+      const newTimeout = Duration(milliseconds: 2000);
       final joinPush = channel.subscribe(timeout: newTimeout);
 
-      expect(joinPush.timeout, const Duration(seconds: 2000));
-    });
-
-    group('timeout behavior', () {
-      T runWithTiming<T>(T Function() callback) {
-        return callback();
-      }
-
-      test('succeeds before timeout', () {
-        final timeout = socket.timeout;
-
-        FakeAsync().run((async) {
-          runWithTiming(() {
-            socket.connect();
-            async.elapse(timeout ~/ 2);
-            channel.trigger('ok');
-            // expect(channel.state, 'joined');
-            // assert.equal(channel.state, 'joined')
-            async.elapse(timeout);
-            // expect(push called, 1);
-            // assert.equal(spy.callCount, 1)
-          });
-        });
-      });
+      expect(joinPush.timeout, const Duration(milliseconds: 2000));
     });
   });
 

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -56,8 +56,6 @@ void main() {
   });
 
   group('onError', () {
-    late Push joinPush;
-
     setUp(() {
       socket = RealtimeClient('/socket');
       channel = socket.channel('topic', chanParams: {'one': 'two'});

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -191,7 +191,7 @@ void main() {
       channel.unsubscribe().trigger('ok', {});
 
       expect(socket.channels.length, 1);
-      expect(socket.channels[0], anotherChannel);
+      expect(socket.channels[0].topic, anotherChannel.topic);
     });
 
     test("sets state to closed on 'ok' event", () {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added channel tests in `channel_test.dart`

## What is the current behavior?

Some tests that are present in realtime-js are missing. 

## What is the new behavior?

Added tests that are directly duplicatable from realtime-js

## Additional context

I tried to replicate the JavaScript tests, but some of them relied on accessing private values, or counting invocations of internal methods, which I presumed is the reason why channel tests were missing in this library. 
I omitted those that are hard to directly duplicate. 
