### PR TITLE
fix: can properly unsubscribe from * subscription

### DIFF
--- a/lib/src/realtime_subscription.dart
+++ b/lib/src/realtime_subscription.dart
@@ -198,7 +198,7 @@ class RealtimeSubscription {
     final filtered = _bindings.where((bind) {
       /// bind all realtime events
       if (bind.event == '*') {
-        return event == payload['type'];
+        return event == (payload is Map ? payload['type'] : payload);
       } else {
         return bind.event == event;
       }

--- a/lib/src/realtime_subscription.dart
+++ b/lib/src/realtime_subscription.dart
@@ -134,7 +134,7 @@ class RealtimeSubscription {
     void onClose() {
       socket.log('channel', 'leave $topic');
       trigger(ChannelEvents.close.eventName(),
-          payload: 'leave', ref: joinRef());
+          payload: {'type': 'leave'}, ref: joinRef());
     }
 
     _state = ChannelStates.leaving;

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -201,5 +201,14 @@ void main() {
 
       expect(channel.isClosed(), true);
     });
+
+    test("able to unsubscribe from * subscription", () {
+      channel.on('*', (payload, {ref}) {});
+      expect(socket.channels.length, 1);
+
+      channel.unsubscribe().trigger('ok', {});
+
+      expect(socket.channels.length, 0);
+    });
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Closes https://github.com/supabase/realtime-dart/issues/17

## What is the current behavior?

When a user tries to unsubscribe from `SupabaseEventTypes.all`, it throws an exception. 

## What is the new behavior?

Exception does not occur and the user can properly unsubscribe.