### PR TITLE
fix: heartbeatTimer canceled on both socket status closed and disconnnected

### DIFF
--- a/lib/src/realtime_client.dart
+++ b/lib/src/realtime_client.dart
@@ -294,9 +294,9 @@ class RealtimeClient {
     /// SocketStates.closed: NOT by user, should try to reconnect
     if (connState == SocketStates.closed) {
       _triggerChanError();
-      if (heartbeatTimer != null) heartbeatTimer!.cancel();
       reconnectTimer.scheduleTimeout();
     }
+    if (heartbeatTimer != null) heartbeatTimer!.cancel();
     for (final callback in stateChangeCallbacks['close']!) {
       callback(event);
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a memory leak problem that was caused by the `heartbeatTimer` not being canceled when the user called `socket.disconnect()`.

## What is the current behavior?

`heartbeatTimer` is not being canceled when the user calls `socket.disconnect()`.

## What is the new behavior?

`heartbeatTimer` is canceled on both when the user calls `socket.disconnect()` and when socket closes unexpectedly. 