### PR TITLE
fix: casting convertChangeData as it should always be Map<String, dynamic>

### DIFF
--- a/lib/src/transformers.dart
+++ b/lib/src/transformers.dart
@@ -58,7 +58,7 @@ class PostgresColumn {
 /// convertChangeData([{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}], {first_name: 'Paul', age:'33'}, {})
 /// => { first_name: 'Paul', age: 33 }
 /// ```
-Map convertChangeData(
+Map<String, dynamic> convertChangeData(
     List<Map<String, dynamic>> columns, Map<String, dynamic> records,
     {List<String>? skipTypes}) {
   final result = <String, dynamic>{};


### PR DESCRIPTION
## What kind of change does this PR introduce?

Casts the return type of `convertChangeData` to `Map<String, dynamic>` for better typing. 

## What is the current behavior?

Type is `Map` or `Map<dynamic, dynamic>` right now. 

## What is the new behavior?

Type is `Map<String, dynamic>`. 