### PR TITLE
fix: realtime not emitting array value correctly

### DIFF
--- a/lib/src/transformers.dart
+++ b/lib/src/transformers.dart
@@ -129,8 +129,8 @@ dynamic convertCell(String type, String? stringValue) {
 
     // if data type is an array
     if (type[0] == '_') {
-      final arrayValue = type.substring(1, type.length);
-      return toArray(stringValue, arrayValue);
+      final arrayType = type.substring(1, type.length);
+      return toArray(type: arrayType, stringValue: stringValue);
     }
 
     final typeEnum = PostgresTypes.values
@@ -202,7 +202,7 @@ dynamic convertCell(String type, String? stringValue) {
 /// @example toArray('{}', 'int4')
 /// //=> []
 ///  ```
-List<dynamic> toArray(String type, String stringValue) {
+List<dynamic> toArray({required String type, required String stringValue}) {
   // this takes off the '{' & '}'
   final stringEnriched = stringValue.substring(1, stringValue.length - 1);
 

--- a/test/transformers_test.dart
+++ b/test/transformers_test.dart
@@ -61,4 +61,18 @@ void main() {
     expect(convertChangeData(columns, records),
         {'id': 253, 'name': 'Singapore', 'continent': null});
   });
+
+  group('convertCell', () {
+    test('_int4', () {
+      expect(convertCell('_int4', '{}'), equals([]));
+      expect(convertCell('_int4', '{1}'), equals([1]));
+      expect(convertCell('_int4', '{1,2,3}'), equals([1, 2, 3]));
+    });
+
+    test('_varchar', () {
+      expect(convertCell('_varchar', '{}'), equals([]));
+      expect(convertCell('_varchar', '{foo}'), equals(['foo']));
+      expect(convertCell('_varchar', '{foo,bar}'), equals(['foo', 'bar']));
+    });
+  });
 }

--- a/test/transformers_test.dart
+++ b/test/transformers_test.dart
@@ -3,9 +3,9 @@ import 'package:test/test.dart';
 
 void main() {
   test('transformers toArray', () {
-    expect(toArray('int4', '{}'), equals([]));
-    expect(toArray('int4', '{1}'), equals([1]));
-    expect(toArray('int4', '{1,2,3}'), equals([1, 2, 3]));
+    expect(toArray(type: 'int4', stringValue: '{}'), equals([]));
+    expect(toArray(type: 'int4', stringValue: '{1}'), equals([1]));
+    expect(toArray(type: 'int4', stringValue: '{1,2,3}'), equals([1, 2, 3]));
   });
 
   test('transformers toTimestampString', () {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

Closes https://github.com/supabase/realtime-dart/issues/21
Related https://github.com/supabase/supabase-dart/issues/44

## What is the current behavior?

Parameters sent to `toArray` method was in wrong order, resulting in passing `type` as the `stringValue` and `stringValue` as the `type`. 

## What is the new behavior?

Changed `toArray` to take named parameters to prevent confusion and passing the correct parameters now. 
