### PR TITLE
fix: rename Callback typedef to BindingCallback

### DIFF
--- a/lib/src/realtime_subscription.dart
+++ b/lib/src/realtime_subscription.dart
@@ -3,11 +3,11 @@ import 'push.dart';
 import 'realtime_client.dart';
 import 'retry_timer.dart';
 
-typedef Callback = void Function(dynamic payload, {String? ref});
+typedef BindingCallback = void Function(dynamic payload, {String? ref});
 
 class Binding {
   String event;
-  Callback callback;
+  BindingCallback callback;
 
   Binding(this.event, this.callback);
 }
@@ -93,7 +93,7 @@ class RealtimeSubscription {
         (reason, {ref}) => callback(reason as String?));
   }
 
-  void on(String event, Callback callback) {
+  void on(String event, BindingCallback callback) {
     _bindings.add(Binding(event, callback));
   }
 

--- a/lib/src/realtime_subscription.dart
+++ b/lib/src/realtime_subscription.dart
@@ -3,11 +3,9 @@ import 'push.dart';
 import 'realtime_client.dart';
 import 'retry_timer.dart';
 
-typedef BindingCallback = void Function(dynamic payload, {String? ref});
-
 class Binding {
   String event;
-  BindingCallback callback;
+  void Function(dynamic payload, {String? ref}) callback;
 
   Binding(this.event, this.callback);
 }
@@ -93,7 +91,8 @@ class RealtimeSubscription {
         (reason, {ref}) => callback(reason as String?));
   }
 
-  void on(String event, BindingCallback callback) {
+  void on(
+      String event, void Function(dynamic payload, {String? ref}) callback) {
     _bindings.add(Binding(event, callback));
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Relates to https://github.com/supabase/supabase-dart/issues/46

## What is the new behavior?

Renamed Callback to SupabaseEventCallback

## Additional context

n/a