### PR TITLE
feat: update transformers to accept already transformed walrus changes

### DIFF
--- a/lib/src/transformers.dart
+++ b/lib/src/transformers.dart
@@ -185,33 +185,42 @@ dynamic noop(dynamic value) {
   return value;
 }
 
-dynamic toBoolean(dynamic value) {
+bool? toBoolean(dynamic value) {
   switch (value) {
     case 't':
       return true;
     case 'f':
       return false;
     default:
-      return value;
+      if (value is bool) {
+        return value;
+      }
+      return null;
   }
 }
 
-dynamic toDouble(dynamic value) {
+double? toDouble(dynamic value) {
   if (value is String) {
     try {
       return double.parse(value);
     } catch (_) {}
   }
-  return value;
+  if (value is double) {
+    return value;
+  }
+  return null;
 }
 
-dynamic toInt(dynamic value) {
+int? toInt(dynamic value) {
   if (value is String) {
     try {
       return int.parse(value);
     } catch (_) {}
   }
-  return value;
+  if (value is int) {
+    return value;
+  }
+  return null;
 }
 
 dynamic toIntRange(dynamic value) {

--- a/lib/src/transformers.dart
+++ b/lib/src/transformers.dart
@@ -279,9 +279,9 @@ dynamic toArray(dynamic value, String type) {
 /// @example toTimestampString('2019-09-10 00:00:00')
 /// => '2019-09-10T00:00:00'
 /// ```
-String toTimestampString(dynamic value) {
+String? toTimestampString(dynamic value) {
   if (value is String) {
     return value.replaceAll(' ', 'T');
   }
-  return '';
+  return null;
 }

--- a/lib/src/transformers.dart
+++ b/lib/src/transformers.dart
@@ -278,9 +278,9 @@ dynamic toArray(dynamic value, String type) {
 /// @example toTimestampString('2019-09-10 00:00:00')
 /// => '2019-09-10T00:00:00'
 /// ```
-dynamic toTimestampString(dynamic value) {
+String toTimestampString(dynamic value) {
   if (value is String) {
     return value.replaceAll(' ', 'T');
   }
-  return value;
+  return '';
 }

--- a/lib/src/transformers.dart
+++ b/lib/src/transformers.dart
@@ -159,7 +159,8 @@ dynamic convertCell(String type, dynamic value) {
     case PostgresTypes.jsonb:
       return toJson(value);
     case PostgresTypes.timestamp:
-      return toTimestampString(value); // Format to be consistent with PostgREST
+      return toTimestampString(
+          value.toString()); // Format to be consistent with PostgREST
     case PostgresTypes.abstime: // To allow users to cast it based on Timezone
     case PostgresTypes.date: // To allow users to cast it based on Timezone
     case PostgresTypes.daterange:
@@ -279,7 +280,7 @@ dynamic toArray(dynamic value, String type) {
 /// @example toTimestampString('2019-09-10 00:00:00')
 /// => '2019-09-10T00:00:00'
 /// ```
-String? toTimestampString(dynamic value) {
+String? toTimestampString(String value) {
   if (value is String) {
     return value.replaceAll(' ', 'T');
   }

--- a/lib/src/transformers.dart
+++ b/lib/src/transformers.dart
@@ -160,7 +160,8 @@ dynamic convertCell(String type, dynamic value) {
       return toJson(value);
     case PostgresTypes.timestamp:
       return toTimestampString(
-          value.toString()); // Format to be consistent with PostgREST
+        value.toString(),
+      ); // Format to be consistent with PostgREST
     case PostgresTypes.abstime: // To allow users to cast it based on Timezone
     case PostgresTypes.date: // To allow users to cast it based on Timezone
     case PostgresTypes.daterange:

--- a/lib/src/transformers.dart
+++ b/lib/src/transformers.dart
@@ -59,8 +59,8 @@ class PostgresColumn {
 /// `skipTypes` The array of types that should not be converted
 ///
 /// ```dart
-/// convertChangeData([{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}], {first_name: 'Paul', age:'33'}, {})
-/// => { first_name: 'Paul', age: 33 }
+/// convertChangeData([{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}], {'first_name': 'Paul', 'age':'33'}, {})
+/// => { 'first_name': 'Paul', 'age': 33 }
 /// ```
 Map<String, dynamic> convertChangeData(
   List<Map<String, dynamic>> columns,

--- a/lib/src/transformers.dart
+++ b/lib/src/transformers.dart
@@ -223,14 +223,6 @@ int? toInt(dynamic value) {
   return null;
 }
 
-dynamic toIntRange(dynamic value) {
-  if (value is String) {
-    final arr = json.decode(value);
-    return [int.parse(arr[0] as String), int.parse(arr[1] as String)];
-  }
-  return value;
-}
-
 dynamic toJson(dynamic value) {
   if (value is String) {
     try {
@@ -243,7 +235,7 @@ dynamic toJson(dynamic value) {
   return value;
 }
 
-/// Converts a Postgres Array into a native JS array
+/// Converts a Postgres Array into a native Dart array
 ///
 ///``` dart
 /// @example toArray('{"[2021-01-01,2021-12-31)","(2021-01-01,2021-12-32]"}', 'daterange')

--- a/lib/src/transformers.dart
+++ b/lib/src/transformers.dart
@@ -281,8 +281,8 @@ dynamic toArray(dynamic value, String type) {
 /// @example toTimestampString('2019-09-10 00:00:00')
 /// => '2019-09-10T00:00:00'
 /// ```
-String? toTimestampString(String value) {
-  if (value is String) {
+String? toTimestampString(String? value) {
+  if (value != null) {
     return value.replaceAll(' ', 'T');
   }
   return null;

--- a/lib/src/transformers.dart
+++ b/lib/src/transformers.dart
@@ -183,14 +183,14 @@ dynamic noop(dynamic value) {
   return value;
 }
 
-bool? toBoolean(dynamic value) {
+dynamic toBoolean(dynamic value) {
   switch (value) {
     case 't':
       return true;
     case 'f':
       return false;
     default:
-      return value as bool;
+      return value;
   }
 }
 

--- a/test/socket_test.dart
+++ b/test/socket_test.dart
@@ -50,7 +50,6 @@ void main() {
         'error': [],
         'message': [],
       });
-      expect(socket.transport is WebSocketChannelClosure, true);
       expect(socket.timeout, const Duration(milliseconds: 10000));
       expect(socket.longpollerTimeout, 20000);
       expect(socket.heartbeatIntervalMs, 30000);
@@ -62,7 +61,6 @@ void main() {
         ),
         false,
       );
-      expect(socket.reconnectAfterMs is Function, true);
       expect(
         socket.headers['X-Client-Info']!.split('/').first,
         'realtime-dart',
@@ -89,7 +87,6 @@ void main() {
         'error': [],
         'message': [],
       });
-      expect(socket.transport is WebSocketChannelClosure, true);
       expect(socket.timeout, const Duration(milliseconds: 40000));
       expect(socket.longpollerTimeout, 50000);
       expect(socket.heartbeatIntervalMs, 60000);
@@ -101,7 +98,6 @@ void main() {
         ),
         true,
       );
-      expect(socket.reconnectAfterMs is Function, true);
       expect(socket.headers['X-Client-Info'], 'supabase-dart/0.0.0');
     });
   });

--- a/test/transformers_test.dart
+++ b/test/transformers_test.dart
@@ -23,15 +23,6 @@ void main() {
     expect(noop('abc'), equals('abc'));
   });
 
-  test('transformers toDateRange', () {
-    expect(
-      toDateRange('["2020-10-30 12:34:56", "2020-11-01 01:23:45"]'),
-      equals(
-        [DateTime(2020, 10, 30, 12, 34, 56), DateTime(2020, 11, 1, 1, 23, 45)],
-      ),
-    );
-  });
-
   group('transformers convertChangeData', () {
     test('with basic usecase', () {
       final columns = [
@@ -140,18 +131,18 @@ void main() {
   });
 
   test('transformers toArray', () {
-    expect(toArray(type: 'int4', stringValue: '{}'), equals([]));
-    expect(toArray(type: 'int4', stringValue: '{1}'), equals([1]));
-    expect(toArray(type: 'int4', stringValue: '{1,2,3}'), equals([1, 2, 3]));
+    expect(toArray('{}', 'int4'), equals([]));
+    expect(toArray('{1}', 'int4'), equals([1]));
+    expect(toArray('{1,2,3}', 'int4'), equals([1, 2, 3]));
     expect(
       toArray(
-        type: 'daterange',
-        stringValue: '{"[2021-01-01,2021-12-31)","(2021-01-01,2021-12-32]"}',
+        '{"[2021-01-01,2021-12-31)","(2021-01-01,2021-12-32]"}',
+        'daterange',
       ),
       ['[2021-01-01,2021-12-31)', '(2021-01-01,2021-12-32]'],
     );
     expect(
-      toArray(type: 'int8', stringValue: [99, 999, 9999, 99999]),
+      toArray([99, 999, 9999, 99999], 'int8'),
       [99, 999, 9999, 99999],
     );
   });

--- a/test/transformers_test.dart
+++ b/test/transformers_test.dart
@@ -12,9 +12,9 @@ void main() {
   test('transformers toBoolean', () {
     expect(toBoolean('t'), isTrue);
     expect(toBoolean('f'), isFalse);
-    expect(toBoolean('abc'), throwsException);
+    expect(toBoolean(true), isTrue);
+    expect(toBoolean(false), isFalse);
     expect(toBoolean(null), isNull);
-    expect(toBoolean(''), throwsException);
   });
 
   test('transformers noop', () {
@@ -110,7 +110,9 @@ void main() {
     });
 
     test('float8', () {
-      expect(convertCell('float8', null), isNull);
+      expect(convertCell('float8', '1.23'), 1.23);
+      expect(convertCell('float8', 1.23), 1.23);
+      expect(convertCell('float8', null), null);
     });
 
     test('json', () {
@@ -122,6 +124,7 @@ void main() {
       expect(convertCell('_int4', '{}'), equals([]));
       expect(convertCell('_int4', '{1}'), equals([1]));
       expect(convertCell('_int4', '{1,2,3}'), equals([1, 2, 3]));
+      expect(convertCell('_int4', [1, 2, 3]), equals([1, 2, 3]));
     });
 
     test('_varchar', () {

--- a/test/transformers_test.dart
+++ b/test/transformers_test.dart
@@ -12,9 +12,9 @@ void main() {
   test('transformers toBoolean', () {
     expect(toBoolean('t'), isTrue);
     expect(toBoolean('f'), isFalse);
-    expect(toBoolean('abc'), 'abc');
+    expect(toBoolean('abc'), throwsException);
     expect(toBoolean(null), isNull);
-    expect(toBoolean(''), '');
+    expect(toBoolean(''), throwsException);
   });
 
   test('transformers noop', () {
@@ -48,7 +48,7 @@ void main() {
       final records = {'id': '253', 'name': 'Singapore', 'continent': null};
       expect(
         convertChangeData(columns, records),
-        {'id': 253, 'name': 'Singapore', 'continent': null},
+        equals({'id': 253, 'name': 'Singapore', 'continent': null}),
       );
     });
 
@@ -114,7 +114,8 @@ void main() {
     });
 
     test('json', () {
-      expect(convertCell('json', '"[1,2,3]"'), '[1,2,3]');
+      expect(convertCell('json', '"[1,2,3]"'), equals('[1,2,3]'));
+      expect(convertCell('json', '[1,2,3]'), equals([1, 2, 3]));
     });
 
     test('_int4', () {
@@ -139,11 +140,11 @@ void main() {
         '{"[2021-01-01,2021-12-31)","(2021-01-01,2021-12-32]"}',
         'daterange',
       ),
-      ['[2021-01-01,2021-12-31)', '(2021-01-01,2021-12-32]'],
+      equals(['[2021-01-01,2021-12-31)', '(2021-01-01,2021-12-32]']),
     );
     expect(
       toArray([99, 999, 9999, 99999], 'int8'),
-      [99, 999, 9999, 99999],
+      equals([99, 999, 9999, 99999]),
     );
   });
 }

--- a/test/transformers_test.dart
+++ b/test/transformers_test.dart
@@ -12,9 +12,9 @@ void main() {
   test('transformers toBoolean', () {
     expect(toBoolean('t'), isTrue);
     expect(toBoolean('f'), isFalse);
-    expect(toBoolean('abc'), isNull);
+    expect(toBoolean('abc'), 'abc');
     expect(toBoolean(null), isNull);
-    expect(toBoolean(''), isNull);
+    expect(toBoolean(''), '');
   });
 
   test('transformers noop', () {
@@ -92,7 +92,7 @@ void main() {
   group('convertCell', () {
     test('bool', () {
       expect(convertCell('bool', 't'), isTrue);
-      expect(convertCell('bool', 'true'), isTrue);
+      expect(convertCell('bool', true), isTrue);
     });
 
     test('int8', () {

--- a/test/transformers_test.dart
+++ b/test/transformers_test.dart
@@ -2,12 +2,6 @@ import 'package:realtime_client/realtime_client.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('transformers toArray', () {
-    expect(toArray(type: 'int4', stringValue: '{}'), equals([]));
-    expect(toArray(type: 'int4', stringValue: '{1}'), equals([1]));
-    expect(toArray(type: 'int4', stringValue: '{1,2,3}'), equals([1, 2, 3]));
-  });
-
   test('transformers toTimestampString', () {
     expect(
       toTimestampString('2020-10-30 12:34:56'),
@@ -38,36 +32,100 @@ void main() {
     );
   });
 
-  test('transformers convertChangeData', () {
-    final columns = [
-      {
-        'flags': ['key'],
-        'name': 'id',
-        'type': 'int8',
-        'type_modifier': 4294967295
-      },
-      {
-        'flags': [],
-        'name': 'name',
-        'type': 'text',
-        'type_modifier': 4294967295
-      },
-      {
-        'flags': [],
-        'name': 'continent',
-        'type': 'continents',
-        'type_modifier': 4294967295
-      }
-    ];
-    final records = {'id': 253, 'name': 'Singapore', 'continent': null};
-    expect(convertChangeData(columns, records), {
-      'id': 253,
-      'name': 'Singapore',
-      'continent': null,
+  group('transformers convertChangeData', () {
+    test('with basic usecase', () {
+      final columns = [
+        {
+          'flags': ['key'],
+          'name': 'id',
+          'type': 'int8',
+          'type_modifier': 4294967295
+        },
+        {
+          'flags': [],
+          'name': 'name',
+          'type': 'text',
+          'type_modifier': 4294967295
+        },
+        {
+          'flags': [],
+          'name': 'continent',
+          'type': 'continents',
+          'type_modifier': 4294967295
+        }
+      ];
+      final records = {'id': '253', 'name': 'Singapore', 'continent': null};
+      expect(
+        convertChangeData(columns, records),
+        {'id': 253, 'name': 'Singapore', 'continent': null},
+      );
+    });
+
+    test('with int in record value', () {
+      final columns = [
+        {
+          'name': 'first_name',
+          'type': 'text',
+        },
+        {
+          'name': 'age',
+          'type': 'int4',
+        }
+      ];
+      final records = {'first_name': 'Mark', 'age': 23};
+      expect(
+        convertChangeData(columns, records),
+        {'first_name': 'Mark', 'age': 23},
+      );
+    });
+
+    test('with null in record value', () {
+      final columns = [
+        {
+          'name': 'first_name',
+          'type': 'text',
+        },
+        {
+          'name': 'age',
+          'type': 'int4',
+        }
+      ];
+      final records = {'first_name': 'Paul', 'age': null};
+      expect(
+        convertChangeData(columns, records),
+        {'first_name': 'Paul', 'age': null},
+      );
     });
   });
 
   group('convertCell', () {
+    test('bool', () {
+      expect(convertCell('bool', 't'), isTrue);
+      expect(convertCell('bool', 'true'), isTrue);
+    });
+
+    test('int8', () {
+      expect(convertCell('int8', '10'), 10);
+      expect(convertCell('int8', 10), 10);
+    });
+
+    test('numeric', () {
+      expect(convertCell('numeric', '12345.12345'), 12345.12345);
+      expect(convertCell('numeric', 12345.12345), 12345.12345);
+    });
+
+    test('int4range', () {
+      expect(convertCell('int4range', '[1,10)'), '[1,10)');
+    });
+
+    test('float8', () {
+      expect(convertCell('float8', null), isNull);
+    });
+
+    test('json', () {
+      expect(convertCell('json', '"[1,2,3]"'), '[1,2,3]');
+    });
+
     test('_int4', () {
       expect(convertCell('_int4', '{}'), equals([]));
       expect(convertCell('_int4', '{1}'), equals([1]));
@@ -79,5 +137,22 @@ void main() {
       expect(convertCell('_varchar', '{foo}'), equals(['foo']));
       expect(convertCell('_varchar', '{foo,bar}'), equals(['foo', 'bar']));
     });
+  });
+
+  test('transformers toArray', () {
+    expect(toArray(type: 'int4', stringValue: '{}'), equals([]));
+    expect(toArray(type: 'int4', stringValue: '{1}'), equals([1]));
+    expect(toArray(type: 'int4', stringValue: '{1,2,3}'), equals([1, 2, 3]));
+    expect(
+      toArray(
+        type: 'daterange',
+        stringValue: '{"[2021-01-01,2021-12-31)","(2021-01-01,2021-12-32]"}',
+      ),
+      ['[2021-01-01,2021-12-31)', '(2021-01-01,2021-12-32]'],
+    );
+    expect(
+      toArray(type: 'int8', stringValue: [99, 999, 9999, 99999]),
+      [99, 999, 9999, 99999],
+    );
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Maintains existing output of realtime changes while making it compatible with walrus changes since walrus will pass through, via realtime, the actual values based on data types. For example, instead of delivering '{1, 2, 3}' for _int4 which has to be transformed by clients, realtime is sending [1, 2, 3] to clients. See this PR comment for more context.

Related https://github.com/supabase/supabase-dart/issues/56
Related https://github.com/supabase/realtime-js/pull/107

## What is the current behavior?

Transformers are not compatible with walrus changes. 

## What is the new behavior?

Transformers play nicely with walrus changes as well as existing realtime changes.

## Other context

Also changed the order of transformer tests to match the order of js library. 