### PR TITLE
chore: publish version 0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.12]
+
+- feat: update transformers to accept already transformed walrus changes
+
 ## [0.1.11]
 
 - chore: added X-Client-Info header

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.1.11';
+const version = '0.1.12';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: realtime_client
 description: Listens to changes in a PostgreSQL Database and via websockets. This is for usage with Supabase Realtime server.
-version: 0.1.11
+version: 0.1.12
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/realtime-dart'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Publish versionn 0.1.12, which includes the following change:
- feat: update transformers to accept already transformed walrus changes