### PR TITLE
fix: export realtime presence

### DIFF
--- a/lib/realtime_client.dart
+++ b/lib/realtime_client.dart
@@ -1,3 +1,4 @@
-export 'src/realtime_client.dart';
 export 'src/realtime_channel.dart' hide ToType;
+export 'src/realtime_client.dart';
+export 'src/realtime_presence.dart';
 export 'src/transformers.dart' hide getEnrichedPayload, getPayloadRecords;

--- a/lib/src/realtime_channel.dart
+++ b/lib/src/realtime_channel.dart
@@ -4,7 +4,6 @@ import 'dart:convert';
 import 'package:realtime_client/realtime_client.dart';
 import 'package:realtime_client/src/constants.dart';
 import 'package:realtime_client/src/push.dart';
-import 'package:realtime_client/src/realtime_presence.dart';
 import 'package:realtime_client/src/retry_timer.dart';
 import 'package:realtime_client/src/transformers.dart';
 


### PR DESCRIPTION
Do we want to hide the `typedef`s instead?
close #309